### PR TITLE
any node lang attribute + consider html lang='..' as a fallback

### DIFF
--- a/freshlate/main.ts
+++ b/freshlate/main.ts
@@ -7,7 +7,17 @@ export default async function hydrate(
 ) {
   options.languages = state;
 
-  let language = document.body.lang;
+  // First, check html lang=".."
+  // - html lang is a standard feature, also cover the head tag, 
+  //   but is not good for reactive translations
+  let language = document.documentElement.lang;
+
+  // Therefore - we allow overriding by body lang=".."
+  // - Which works, but are not actually supported to 
+  //   change by fresh, yet...
+  if (document.body.lang) {
+    language = document.body.lang;
+  }
 
   // If no language was passed in, try to get it from the browser
   if (!language || language === "") {

--- a/freshlate/shared.ts
+++ b/freshlate/shared.ts
@@ -62,6 +62,11 @@ export function setup(options: Options, language?: string) {
         translate_props.lang = language;
       }
 
+      // If the vnode has a lang attribute, use that instead
+      if (props?.["lang"]) {
+        translate_props.lang = props?.["lang"];
+      }
+
       // If the key is an array, map over all items and translate them if necessary
       if (Array.isArray(props.children)) {
         // Map over the children and translate them if necessary


### PR DESCRIPTION
Proposed changed related to issue #1 
* Consider node lang=".."
* Consider html lang=".." as a fallback to body lang=".." 

(More info: https://www.w3.org/International/questions/qa-html-language-declarations)